### PR TITLE
Add `wp_has_gravatar_logo` function for themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "WP Gravatar Logo",
-  "slug": "wp-gravatar-logo",  
+  "slug": "wp-gravatar-logo",
   "textdomain": "wp-gravatar-logo",
-  "version": "1.0.2",
-  "description": "The simplest way to use a Gravatar as your website's logo within the WordPress Customizer.",  
+  "version": "1.1.0",
+  "description": "The simplest way to use a Gravatar as your website's logo within the WordPress Customizer.",
   "plugin_uri": "https://themebeans.com/plugins/wp-gravatar-logo",
   "author": "Rich Tabor of ThemeBeans <hello@themebeans.com>",
   "author_uri": "https://themebeans.com",

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,10 @@ WP Gravatar Logo is the easiest way to use a Gravatar as your website's logo wit
 
 == Changelog ==
 
+= 1.1.0 =
+* Add method to validate the Gravater URL being used includes a hash.
+* Add global helper method to access new validation method.
+
 = 1.0.2 =
 * Minor Customizer priority fix
 

--- a/wp-gravatar-logo.php
+++ b/wp-gravatar-logo.php
@@ -190,6 +190,27 @@ if ( ! class_exists( 'WP_Gravatar_Logo' ) ) :
 		}
 
 		/**
+		 * Determines whether the site has a valid gravater logo.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @return bool Whether the site has a valid gravater logo or not.
+		 */
+		public static function has_gravatar() {
+			/**
+			 * Filter the author avatar. Defaults to the admin's email address.
+			 */
+			$avatar = get_theme_mod( 'wp_gravatar_logo__email', get_bloginfo( 'admin_email' ) );
+			$avatar_url = get_avatar_url( $avatar, 42 ); // Size doesn't matter for this test.
+			// When a Gravatar is invalid it will have a URL without a hash
+			// between the '/avatar/' & Query Paramaters. So when this result is
+			// 'true' we know that no valid Garvatar was found.
+			$results = preg_grep('/\/avatar\/\?s/', explode("\n", $avatar_url));
+			$status = (bool) $results;
+			return ! $status;
+		}
+
+		/**
 		 * Plugins row action links.
 		 *
 		 * @param array|string  $links already defined action links.
@@ -237,6 +258,24 @@ endif;
 function wp_gravatar_logo() {
 	return WP_Gravatar_Logo::instance();
 }
+
+/**
+ * A helper function to quickly check for a valid gravatar logo.
+ *
+ * A globally accesible function for determining the sites access to a vaild
+ * gravatar based logo.
+ *
+ * For use in themes the same way `has_custom_logo` is used.
+ *
+ * Example: <?php if ( has_custom_logo() || ( function_exists('wp_has_gravatar_logo') && wp_has_gravatar_logo() ) ) : ?>
+ *
+ * @since 1.1.0
+ * @return bool Whether the site has a valid gravater logo or not.
+ */
+function wp_has_gravatar_logo() {
+	return WP_Gravatar_Logo::has_gravatar();
+}
+
 
 // Get WP_Gravatar_Logo Running.
 wp_gravatar_logo();


### PR DESCRIPTION
This PR fixes #1 by adding the proposed method and global helper. Includes a minor version bump (per semver) since it's adding functionality in a backwards-compatible manner.

Adds a public class method `has_gravatar` that validates the Gravatar URL. The new method utilizes some regex on the URL to ensure it contains a hash string. Rather than validating the hash string itself, it just ensures that there is a string in the expected position.